### PR TITLE
修复了长短信转发不会聚合的Bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.SEND_SMS" />
     <uses-permission android:name="android.permission.READ_SMS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
-
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -22,6 +22,13 @@
 
         <service android:name="cc.mightu.sms_forward.ForwardSMSService"/>
 
+        <receiver android:name=".BootBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"></action>
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </receiver>
+        
     </application>
 
 </manifest>

--- a/app/src/main/java/cc/mightu/sms_forward/BootBroadcastReceiver.java
+++ b/app/src/main/java/cc/mightu/sms_forward/BootBroadcastReceiver.java
@@ -1,0 +1,17 @@
+package cc.mightu.sms_forward;
+
+import android.content.BroadcastReceiver;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+public class BootBroadcastReceiver extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Intent mBootIntent = new Intent(context, MainActivity.class);
+        mBootIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(mBootIntent);
+    }
+}

--- a/app/src/main/java/cc/mightu/sms_forward/ForwardSMSService.java
+++ b/app/src/main/java/cc/mightu/sms_forward/ForwardSMSService.java
@@ -57,7 +57,7 @@ public class ForwardSMSService extends Service {
                         message_total = message_total + messageBody;
                     }
 
-                    message_total = message_total + "\n[ from " + address + "] ";
+                    message_total = message_total + "\n[from " + address + "] ";
                     String number = context.getSharedPreferences("data", Context.MODE_PRIVATE).getString("number", "");
                     if (number == "") {
                         Log.i("sms", "phone number not set. ignore this one.");

--- a/app/src/main/java/cc/mightu/sms_forward/ForwardSMSService.java
+++ b/app/src/main/java/cc/mightu/sms_forward/ForwardSMSService.java
@@ -46,29 +46,29 @@ public class ForwardSMSService extends Service {
             if(Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(action)){
                 Log.i("sms", "on receive," + intent.getAction());
                 if (Telephony.Sms.Intents.SMS_RECEIVED_ACTION.equals(intent.getAction())) {
+                    String message_total = "";
+                    String address = "";
                     for (SmsMessage smsMessage : Telephony.Sms.Intents.getMessagesFromIntent(intent)) {
-
-                        String messageBody = smsMessage.getMessageBody();
                         String emailFrom = smsMessage.getEmailFrom();
-                        String address = smsMessage.getOriginatingAddress();
+                        address = smsMessage.getOriginatingAddress();
+                        String messageBody = smsMessage.getMessageBody();
                         Log.i("sms", "body: " + messageBody);
                         Log.i("sms", "address: " + address);
-
-                        String message = "[" + address + "] " + messageBody;
-
-                        String number = context.getSharedPreferences("data", Context.MODE_PRIVATE).getString("number", "");
-                        if (number == "") {
-                            Log.i("sms", "phone number not set. ignore this one.");
-                            return;
-                        }
-                        Log.i("sms", "sending to " + number);
-
-                        Log.i("sms", "message send:" + message);
-                        SmsManager sms = SmsManager.getDefault();
-                        ArrayList<String> dividedMessages = sms.divideMessage(message);
-                        sms.sendMultipartTextMessage(number, null, dividedMessages, null, null);
+                        message_total = message_total + messageBody;
                     }
-                }
+
+                    message_total = message_total + "\n[ from " + address + "] ";
+                    String number = context.getSharedPreferences("data", Context.MODE_PRIVATE).getString("number", "");
+                    if (number == "") {
+                        Log.i("sms", "phone number not set. ignore this one.");
+                        return;
+                    }
+                    Log.i("sms", "sending to " + number);
+
+                    Log.i("sms", "message send:" + message_total);
+                    SmsManager sms = SmsManager.getDefault();
+                    ArrayList<String> dividedMessages = sms.divideMessage(message_total);
+                    sms.sendMultipartTextMessage(number, null, dividedMessages, null, null);
             }
         }
     };

--- a/app/src/main/java/cc/mightu/sms_forward/MainActivity.java
+++ b/app/src/main/java/cc/mightu/sms_forward/MainActivity.java
@@ -82,9 +82,9 @@ public class MainActivity extends AppCompatActivity {
         editor.putString("number", number);
         editor.apply();
 
-        String message = "This is a test message to " + number;
-        Log.i("sms", "message send:" + message);
-
+        //String message = "This is a test message to " + number;
+        //Log.i("sms", "message send:" + message);
+        Toast.makeText(getApplicationContext(), "设置成功", Toast.LENGTH_SHORT).show();
 //        SmsManager smsManager = SmsManager.getDefault();
 //        smsManager.sendTextMessage(number, null, message, null, null);
     }


### PR DESCRIPTION
发送长短信时，系统会将多条信息聚合显示，而clean-sms-forwarding会分成独立的多条短信转发出去。修复了这个bug之后，转发后的长短信也会聚合成一条短信。